### PR TITLE
Use the official archive of zlib

### DIFF
--- a/modulesets-stable/gtk-osx-network.modules
+++ b/modulesets-stable/gtk-osx-network.modules
@@ -33,7 +33,7 @@
               href="https://github.com/"
               type="tarball" />
   <repository name="zlib"
-              href="https://www.zlib.net/"
+              href="https://zlib.net/fossils/"
               type="tarball" />
   <!--
     Builds latest stable version of WebKitGTK for GTK 3.x
@@ -103,9 +103,9 @@
   </autotools>
   <!---->
   <cmake id="zlib">
-    <branch module="zlib-1.2.13.tar.xz"
+    <branch module="zlib-1.2.13.tar.gz"
             version="1.2.13"
-            hash="sha256:d14c38e313afc35a9a8760dadf26042f51ea0f5d154b0630a31da0540107fb98"
+            hash="sha256:b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30"
             repo="zlib" />
   </cmake>
   <!---->


### PR DESCRIPTION
zlib.net only has the latest version in the "root". The latest version is now 1.3, so 1.2.13 is relegated to the 'fossils' archive.

The 'fossils' link is described as: "All released versions of zlib" so should work in the future too.

I don't see an official SHA256 for the file on the zlib.net site, so SHA256 calculated as follows:
 - download the tar.gz
 - verify contents manually
 - shasum -a 256 <tarball>