### PR TITLE
Remove -I and -L flags from CPPFLAGS, CFLAGS, CXXFLAGS, OBJCFLAGS, LDFLAGS.

### DIFF
--- a/gtk-osx-setup.sh
+++ b/gtk-osx-setup.sh
@@ -251,7 +251,7 @@ fi
 
 $PIPENV install
 
-BASEURL="https://gitlab.gnome.org/GNOME/gtk-osx/raw/master"
+BASEURL="https://raw.githubusercontent.com/Xpra-org/gtk-osx-build/master"
 
 config_dir=""
 if test -n "$XDG_CONFIG_HOME"; then

--- a/jhbuildrc-gtk-osx
+++ b/jhbuildrc-gtk-osx
@@ -251,11 +251,6 @@ def setup_sdk(target=_target, sdk_version=None, architectures=[_default_arch]):
     sdkdir = _popen("xcrun --show-sdk-path")
 
     if sdkdir:
-        environ_prepend("LDFLAGS", "-L" + sdkdir + "/usr/lib")
-        environ_prepend("CFLAGS", "-I" + sdkdir + "/usr/include")
-        environ_prepend("CXXFLAGS", "-I" + sdkdir + "/usr/include")
-        environ_prepend("OBJCFLAGS", "-I" + sdkdir + "/usr/include")
-        environ_prepend("CPPFLAGS", "-I" + sdkdir + "/usr/include")
         environ_prepend("CMAKE_PREFIX_PATH", os.path.join(sdkdir, 'usr'), ':')
         environ_prepend("LIBRARY_PATH", sdkdir + "/usr/lib", ':')
 


### PR DESCRIPTION
Note there are **two** significant commits here:

* **Fetch jhbuildrc-gtk-osx from xpra fork.** This is necessary for any local changes to jhbuildrc-gtk-osx to take effect. Note that the local fork of jhbuildrc-gtk-osx has drifted from upstream: https://paste.debian.net/1310060/ The diff seems benign. See this CI run which succeeded with the local fork: https://github.com/cpatulea/gtk-osx-build/actions/runs/8151698638
* **Remove -I and -L flags from CPPFLAGS, CFLAGS, CXXFLAGS, OBJCFLAGS, LDFLAGS.** This is the main change. It should fix the build of libvpx 1.14.0 (see discussion: https://github.com/Xpra-org/gtk-osx-build/commit/0a1a8d83ef52f08c3266baeb9ed7f1d8dc6ee761). Same CI run as above ran with this change and shows the build succeeds with this change. Upstream gtk-osx-build may look at this change and consider merging it in ~April 2024.