### PR TITLE
python3-nacl: add dep on python3-cffi

### DIFF
--- a/xpra-python3.modules
+++ b/xpra-python3.modules
@@ -292,6 +292,7 @@
 			version="1.5.0"/>
 		<dependencies>
 			<dep package="python3"/>
+			<dep package="python3-cffi"/>
 		</dependencies>
 		<after>
 			<dep package="python3"/>


### PR DESCRIPTION
Without this, if python3-nacl happens to be built first, setuptools tries to fetch it from Pypi as an egg, which fails.

After this, CI runs passes on both x86_64 and arm64: https://github.com/cpatulea/gtk-osx-build/actions/runs/8255381710